### PR TITLE
Bump version to ligo 1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ test: ## run tests (SUITE=asset_approve make test)
 ifndef SUITE
 	@$(call test,asset_transfer.test.mligo)
 	@$(call test,asset_approve.test.mligo)
+	@$(call test,asset_extra_entrypoint.test.mligo)
 else
 	@$(call test,$(SUITE).test.mligo)
 endif

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LIGO=docker run --platform linux/amd64 -u $(id -u):$(id -g) --rm -v "$(PWD)":"$(
 endif
 # ^ use LIGO en var bin if configured, otherwise use docker
 
-compile = $(LIGO) compile contract -m FA12_TOKEN --project-root ./lib ./lib/$(1) -o ./compiled/$(2) $(3) 
+compile = $(LIGO) compile contract  --project-root ./lib ./lib/$(1) -o ./compiled/$(2) $(3) 
 # ^ Compile contracts to Michelson or Micheline
 
 test = @$(LIGO) run test $(project_root) ./test/$(1)

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ help:
 	awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 ifndef LIGO
-LIGO=docker run --platform linux/amd64 -u $(id -u):$(id -g) --rm -v "$(PWD)":"$(PWD)" -w "$(PWD)" ligolang/ligo:0.67.1
+LIGO=docker run --platform linux/amd64 -u $(id -u):$(id -g) --rm -v "$(PWD)":"$(PWD)" -w "$(PWD)" ligolang/ligo:1.2.0
 endif
 # ^ use LIGO en var bin if configured, otherwise use docker
 
-compile = $(LIGO) compile contract --project-root ./lib ./lib/$(1) -o ./compiled/$(2) $(3) 
+compile = $(LIGO) compile contract -m FA12_TOKEN --project-root ./lib ./lib/$(1) -o ./compiled/$(2) $(3) 
 # ^ Compile contracts to Michelson or Micheline
 
 test = @$(LIGO) run test $(project_root) ./test/$(1)

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,3 @@ ifndef SUITE
 else
 	@$(call test,$(SUITE).test.mligo)
 endif
-
-login:
-	@$(LIGO) login
-
-publish: ## publish package on packages.ligolang.org
-	@$(LIGO) publish

--- a/README.md
+++ b/README.md
@@ -45,10 +45,9 @@ make test
 ```
 
 ### Publishing to Ligolang
-
-To publish this repository on https://packages.ligolang.org/packages
 (For members only)
+To publish this repository on https://packages.ligolang.org/packages
 ```
-make login
-make publish
+ligo login
+ligo publish
 ```

--- a/lib/asset/fa12.mligo
+++ b/lib/asset/fa12.mligo
@@ -1,56 +1,59 @@
-#import "errors.mligo" "Errors"
-#import "allowance.mligo" "Allowance"
-#import "ledger.mligo" "Ledger"
-#import "token_metadata.mligo" "TokenMetadata"
-#import "storage.mligo" "Storage"
+// module FA12 = struct
 
-type storage = Storage.t
+   #import "errors.mligo" "Errors"
+   #import "allowance.mligo" "Allowance"
+   #import "ledger.mligo" "Ledger"
+   #import "token_metadata.mligo" "TokenMetadata"
+   #import "storage.mligo" "Storage"
 
-// /** transfer entrypoint */
-type transfer = (address * (address * nat))
-let transfer ((from_, to_value), s : transfer * storage) : operation list * storage =
-   let (to_, value) = to_value in
-   let ledger1 = Storage.get_ledger s in
-   let ledger2 = Ledger.decrease_token_amount_for_user ledger1 (Tezos.get_sender ()) from_ value in
-   let ledger = Ledger.increase_token_amount_for_user ledger2 to_ value in
-   let s1 = Storage.set_ledger s ledger in
-   (([] : operation list), s1)
+   type storage = Storage.t
 
-// /** approve */
-type approve = address * nat
-let approve ((spender,value), s : approve * storage) : operation list * storage =
-   let ledger1 = Storage.get_ledger s in
-   let ledger = Ledger.set_approval ledger1 (Tezos.get_sender ()) spender value in
-   let s1 = Storage.set_ledger s ledger in
-   (([] : operation list), s1)
+   // /** transfer entrypoint */
+   type transfer = (address * (address * nat))
+   let transfer ((from_, to_value), s: transfer * storage) : operation list * storage =
+      let (to_, value) = to_value in
+      let ledger1 = Storage.get_ledger s in
+      let ledger2 = Ledger.decrease_token_amount_for_user ledger1 (Tezos.get_sender ()) from_ value in
+      let ledger = Ledger.increase_token_amount_for_user ledger2 to_ value in
+      let s1 = Storage.set_ledger s ledger in
+      (([] : operation list), s1)
 
-// /** getAllowance entrypoint */
-type getAllowance = ((address * address) * nat contract)
-let getAllowance ((owner_spender,callback), s: getAllowance * storage) : operation list * storage =
-   let (owner,spender) = owner_spender in
-   let a = Storage.get_allowances_for_owner s owner in
-   let allowed_amount = Allowance.get_allowed_amount a spender in
-   let operation = Tezos.transaction allowed_amount 0tez callback in
-   ([operation], s)
+   // /** approve */
+   type approve = address * nat
+   let approve ((spender,value), s : approve * storage) : operation list * storage =
+      let ledger1 = Storage.get_ledger s in
+      let ledger = Ledger.set_approval ledger1 (Tezos.get_sender ()) spender value in
+      let s1 = Storage.set_ledger s ledger in
+      (([] : operation list), s1)
 
-// /** getBalance entrypoint */
-type getBalance = address * nat contract 
-let getBalance ((owner,callback), s : getBalance * storage) : operation list * storage =
-   let balance_ = Storage.get_amount_for_owner s owner in
-   let operation = Tezos.transaction balance_ 0tez callback in
-   ([operation], s)
+   // /** getAllowance entrypoint */
+   type getAllowance = ((address * address) * nat contract)
+   let getAllowance ((owner_spender,callback), s: getAllowance * storage) : operation list * storage =
+      let (owner,spender) = owner_spender in
+      let a = Storage.get_allowances_for_owner s owner in
+      let allowed_amount = Allowance.get_allowed_amount a spender in
+      let operation = Tezos.transaction allowed_amount 0tez callback in
+      ([operation], s)
 
-// /** getTotalSupply entrypoint */
-type getTotalSupply = (unit * nat contract)
-let getTotalSupply ((_,callback), s : getTotalSupply * storage) : operation list * storage =
-   let operation = Tezos.transaction s.total_supply 0tez callback in
-   ([operation], s)
+   // /** getBalance entrypoint */
+   type getBalance = address * nat contract 
+   let getBalance ((owner,callback), s : getBalance * storage) : operation list * storage =
+      let balance_ = Storage.get_amount_for_owner s owner in
+      let operation = Tezos.transaction balance_ 0tez callback in
+      ([operation], s)
 
-type parameter = 
-| Transfer of transfer 
-| Approve of approve 
-| GetAllowance of getAllowance 
-| GetBalance of getBalance 
-| GetTotalSupply of getTotalSupply
+   // /** getTotalSupply entrypoint */
+   type getTotalSupply = (unit * nat contract)
+   let getTotalSupply ((_,callback), s : getTotalSupply * storage) : operation list * storage =
+      let operation = Tezos.transaction s.total_supply 0tez callback in
+      ([operation], s)
+
+   // type parameter = 
+   // | Transfer of transfer 
+   // | Approve of approve 
+   // | GetAllowance of getAllowance 
+   // | GetBalance of getBalance 
+   // | GetTotalSupply of getTotalSupply
 
 
+// end

--- a/lib/asset/fa12.mligo
+++ b/lib/asset/fa12.mligo
@@ -1,59 +1,54 @@
-// module FA12 = struct
+#import "errors.mligo" "Errors"
+#import "allowance.mligo" "Allowance"
+#import "ledger.mligo" "Ledger"
+#import "token_metadata.mligo" "TokenMetadata"
+#import "storage.mligo" "Storage"
 
-   #import "errors.mligo" "Errors"
-   #import "allowance.mligo" "Allowance"
-   #import "ledger.mligo" "Ledger"
-   #import "token_metadata.mligo" "TokenMetadata"
-   #import "storage.mligo" "Storage"
+type storage = Storage.t
 
-   type storage = Storage.t
+// /** transfer entrypoint */
+type transfer = (address * (address * nat))
+let transfer ((from_, to_value), s: transfer * storage) : operation list * storage =
+   let (to_, value) = to_value in
+   let ledger1 = Storage.get_ledger s in
+   let ledger2 = Ledger.decrease_token_amount_for_user ledger1 (Tezos.get_sender ()) from_ value in
+   let ledger = Ledger.increase_token_amount_for_user ledger2 to_ value in
+   let s1 = Storage.set_ledger s ledger in
+   (([] : operation list), s1)
 
-   // /** transfer entrypoint */
-   type transfer = (address * (address * nat))
-   let transfer ((from_, to_value), s: transfer * storage) : operation list * storage =
-      let (to_, value) = to_value in
-      let ledger1 = Storage.get_ledger s in
-      let ledger2 = Ledger.decrease_token_amount_for_user ledger1 (Tezos.get_sender ()) from_ value in
-      let ledger = Ledger.increase_token_amount_for_user ledger2 to_ value in
-      let s1 = Storage.set_ledger s ledger in
-      (([] : operation list), s1)
+// /** approve */
+type approve = address * nat
+let approve ((spender,value), s : approve * storage) : operation list * storage =
+   let ledger1 = Storage.get_ledger s in
+   let ledger = Ledger.set_approval ledger1 (Tezos.get_sender ()) spender value in
+   let s1 = Storage.set_ledger s ledger in
+   (([] : operation list), s1)
 
-   // /** approve */
-   type approve = address * nat
-   let approve ((spender,value), s : approve * storage) : operation list * storage =
-      let ledger1 = Storage.get_ledger s in
-      let ledger = Ledger.set_approval ledger1 (Tezos.get_sender ()) spender value in
-      let s1 = Storage.set_ledger s ledger in
-      (([] : operation list), s1)
+// /** getAllowance entrypoint */
+type getAllowance = ((address * address) * nat contract)
+let getAllowance ((owner_spender,callback), s: getAllowance * storage) : operation list * storage =
+   let (owner,spender) = owner_spender in
+   let a = Storage.get_allowances_for_owner s owner in
+   let allowed_amount = Allowance.get_allowed_amount a spender in
+   let operation = Tezos.transaction allowed_amount 0tez callback in
+   ([operation], s)
 
-   // /** getAllowance entrypoint */
-   type getAllowance = ((address * address) * nat contract)
-   let getAllowance ((owner_spender,callback), s: getAllowance * storage) : operation list * storage =
-      let (owner,spender) = owner_spender in
-      let a = Storage.get_allowances_for_owner s owner in
-      let allowed_amount = Allowance.get_allowed_amount a spender in
-      let operation = Tezos.transaction allowed_amount 0tez callback in
-      ([operation], s)
+// /** getBalance entrypoint */
+type getBalance = address * nat contract 
+let getBalance ((owner,callback), s : getBalance * storage) : operation list * storage =
+   let balance_ = Storage.get_amount_for_owner s owner in
+   let operation = Tezos.transaction balance_ 0tez callback in
+   ([operation], s)
 
-   // /** getBalance entrypoint */
-   type getBalance = address * nat contract 
-   let getBalance ((owner,callback), s : getBalance * storage) : operation list * storage =
-      let balance_ = Storage.get_amount_for_owner s owner in
-      let operation = Tezos.transaction balance_ 0tez callback in
-      ([operation], s)
+// /** getTotalSupply entrypoint */
+type getTotalSupply = (unit * nat contract)
+let getTotalSupply ((_,callback), s : getTotalSupply * storage) : operation list * storage =
+   let operation = Tezos.transaction s.total_supply 0tez callback in
+   ([operation], s)
 
-   // /** getTotalSupply entrypoint */
-   type getTotalSupply = (unit * nat contract)
-   let getTotalSupply ((_,callback), s : getTotalSupply * storage) : operation list * storage =
-      let operation = Tezos.transaction s.total_supply 0tez callback in
-      ([operation], s)
-
-   // type parameter = 
-   // | Transfer of transfer 
-   // | Approve of approve 
-   // | GetAllowance of getAllowance 
-   // | GetBalance of getBalance 
-   // | GetTotalSupply of getTotalSupply
-
-
-// end
+// type parameter = 
+// | Transfer of transfer 
+// | Approve of approve 
+// | GetAllowance of getAllowance 
+// | GetBalance of getBalance 
+// | GetTotalSupply of getTotalSupply

--- a/lib/asset/token_metadata.mligo
+++ b/lib/asset/token_metadata.mligo
@@ -8,4 +8,4 @@ type data = {
     token_info : (string, bytes) map;
 }
 
-type t = data
+type t = (nat, data) big_map

--- a/ligo.json
+++ b/ligo.json
@@ -1,0 +1,21 @@
+{
+    "name": "ligo_fa1.2",
+    "version": "1.0.0",
+    "main": "./lib/asset/fa12.mligo",
+    "description": "Library of FA12",
+    "directories": {
+      "lib": "lib",
+      "test": "test"
+    },
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/frankhillard/ligoFA12.git"
+    },
+    "keywords": ["ligo", "tezos", "FA12"],
+    "author": "Frank Hillard <frank.hillard@gmail.com>",
+    "license": "MIT",
+    "bugs": {
+      "url": "https://github.com/frankhillard/ligoFA12/issues"
+    },
+    "homepage": "https://github.com/frankhillard/ligoFA12"
+  }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ligo_fa1.2",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "main": "./lib/asset/fa12.mligo",
     "description": "Library of FA12",
     "directories": {

--- a/test/asset.instance.mligo
+++ b/test/asset.instance.mligo
@@ -1,5 +1,3 @@
-module FA12_TOKEN = struct
-
   #import "../lib/asset/fa12.mligo" "FA12"
 
   type storage = FA12.storage
@@ -31,15 +29,3 @@ module FA12_TOKEN = struct
   [@entry]
   let getTotalSupply (p: FA12.getTotalSupply) (s: storage) : operation list * storage =
     FA12.getTotalSupply(p, s)
-
-
-  // [@entry]
-  // let main (p: parameter) (s: storage) : operation list * storage =
-  //     match p with
-  //       Transfer p -> FA12.transfer p s
-  //     | Approve p -> FA12.approve(p, s)
-  //     | GetAllowance p -> FA12.getAllowance(p, s)
-  //     | GetBalance p -> FA12.getBalance(p, s)
-  //     | GetTotalSupply p -> FA12.getTotalSupply(p, s)
-
-end

--- a/test/asset.instance.mligo
+++ b/test/asset.instance.mligo
@@ -1,18 +1,44 @@
-#import "../lib/asset/fa12.mligo" "FA12"
+module FA12_TOKEN = struct
 
-type storage = FA12.storage
+  #import "../lib/asset/fa12.mligo" "FA12"
 
-type parameter = [@layout:comb] 
-  Transfer of FA12.transfer 
-| Approve of FA12.approve 
-| GetAllowance of FA12.getAllowance 
-| GetBalance of FA12.getBalance 
-| GetTotalSupply of FA12.getTotalSupply
+  type storage = FA12.storage
 
-let main (p, s : parameter * storage) : operation list * storage =
-    match p with
-      Transfer p -> FA12.transfer(p, s)
-    | Approve p -> FA12.approve(p, s)
-    | GetAllowance p -> FA12.getAllowance(p, s)
-    | GetBalance p -> FA12.getBalance(p, s)
-    | GetTotalSupply p -> FA12.getTotalSupply(p, s)
+  type parameter = [@layout tree]
+  | Approve of FA12.approve 
+  | GetAllowance of FA12.getAllowance 
+  | GetBalance of FA12.getBalance 
+  | GetTotalSupply of FA12.getTotalSupply
+  | Transfer of FA12.transfer
+
+  [@entry]
+  let transfer (p: FA12.transfer) (s: storage) : operation list * storage =
+    FA12.transfer(p, s)
+
+  [@entry]
+  let approve (p: FA12.approve) (s: storage) : operation list * storage =
+    FA12.approve(p, s)
+  
+  [@entry]
+  let getAllowance (p: FA12.getAllowance) (s: storage) : operation list * storage =
+    FA12.getAllowance(p, s)
+
+  [@entry]
+  let getBalance (p: FA12.getBalance) (s: storage) : operation list * storage =
+    FA12.getBalance(p, s)
+
+  [@entry]
+  let getTotalSupply (p: FA12.getTotalSupply) (s: storage) : operation list * storage =
+    FA12.getTotalSupply(p, s)
+
+
+  // [@entry]
+  // let main (p: parameter) (s: storage) : operation list * storage =
+  //     match p with
+  //       Transfer p -> FA12.transfer p s
+  //     | Approve p -> FA12.approve(p, s)
+  //     | GetAllowance p -> FA12.getAllowance(p, s)
+  //     | GetBalance p -> FA12.getBalance(p, s)
+  //     | GetTotalSupply p -> FA12.getTotalSupply(p, s)
+
+end

--- a/test/asset.instance.mligo
+++ b/test/asset.instance.mligo
@@ -3,7 +3,7 @@
 type storage = FA12.storage
 
 type parameter = [@layout comb] 
-| X of unit
+| X of unit     // You can add an additionnal entrypoint to implement a specific feature for the token
 | GetTotalSupply of FA12.getTotalSupply
 | GetBalance of FA12.getBalance  
 | GetAllowance of FA12.getAllowance 

--- a/test/asset.instance.mligo
+++ b/test/asset.instance.mligo
@@ -1,31 +1,36 @@
-  #import "../lib/asset/fa12.mligo" "FA12"
+#import "../lib/asset/fa12.mligo" "FA12"
 
-  type storage = FA12.storage
+type storage = FA12.storage
 
-  type parameter = [@layout comb] 
-  | GetTotalSupply of FA12.getTotalSupply
-  | GetBalance of FA12.getBalance  
-  | GetAllowance of FA12.getAllowance 
-  | Approve of FA12.approve 
-  | Transfer of FA12.transfer
+type parameter = [@layout comb] 
+| X of unit
+| GetTotalSupply of FA12.getTotalSupply
+| GetBalance of FA12.getBalance  
+| GetAllowance of FA12.getAllowance 
+| Approve of FA12.approve 
+| Transfer of FA12.transfer
 
 
-  [@entry]
-  let transfer (p: FA12.transfer) (s: storage) : operation list * storage =
-    FA12.transfer(p, s)
+[@entry]
+let transfer (p: FA12.transfer) (s: storage) : operation list * storage =
+  FA12.transfer(p, s)
 
-  [@entry]
-  let approve (p: FA12.approve) (s: storage) : operation list * storage =
-    FA12.approve(p, s)
-  
-  [@entry]
-  let getAllowance (p: FA12.getAllowance) (s: storage) : operation list * storage =
-    FA12.getAllowance(p, s)
+[@entry]
+let approve (p: FA12.approve) (s: storage) : operation list * storage =
+  FA12.approve(p, s)
 
-  [@entry]
-  let getBalance (p: FA12.getBalance) (s: storage) : operation list * storage =
-    FA12.getBalance(p, s)
+[@entry]
+let getAllowance (p: FA12.getAllowance) (s: storage) : operation list * storage =
+  FA12.getAllowance(p, s)
 
-  [@entry]
-  let getTotalSupply (p: FA12.getTotalSupply) (s: storage) : operation list * storage =
-    FA12.getTotalSupply(p, s)
+[@entry]
+let getBalance (p: FA12.getBalance) (s: storage) : operation list * storage =
+  FA12.getBalance(p, s)
+
+[@entry]
+let getTotalSupply (p: FA12.getTotalSupply) (s: storage) : operation list * storage =
+  FA12.getTotalSupply(p, s)
+
+[@entry]
+let x (_p: unit) (s: storage) : operation list * storage =
+  [], s

--- a/test/asset.instance.mligo
+++ b/test/asset.instance.mligo
@@ -4,12 +4,13 @@ module FA12_TOKEN = struct
 
   type storage = FA12.storage
 
-  type parameter = [@layout tree]
-  | Approve of FA12.approve 
-  | GetAllowance of FA12.getAllowance 
-  | GetBalance of FA12.getBalance 
+  type parameter = [@layout comb] 
   | GetTotalSupply of FA12.getTotalSupply
+  | GetBalance of FA12.getBalance  
+  | GetAllowance of FA12.getAllowance 
+  | Approve of FA12.approve 
   | Transfer of FA12.transfer
+
 
   [@entry]
   let transfer (p: FA12.transfer) (s: storage) : operation list * storage =

--- a/test/asset_approve.test.mligo
+++ b/test/asset_approve.test.mligo
@@ -3,7 +3,7 @@
 #import "./helper/asset.mligo" "Asset_helper"
 #import "./asset.instance.mligo" "Asset"
 
-type storage = Asset.FA12_TOKEN.storage
+type storage = Asset.storage
 
 let test_success_approve =
     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
@@ -25,7 +25,7 @@ let test_failure_approve_modify_allowance =
     let () = Test.set_source owner1 in
     let approve_op1 = (op1, 1n) in
     let r = Test.transfer_to_contract asset.contr (Approve approve_op1) 0tez in
-    Assert.string_failure r Asset.FA12_TOKEN.FA12.Errors.vulnerable_operation
+    Assert.string_failure r Asset.FA12.Errors.vulnerable_operation
 
 let test_success_approve_modify_allowance =
     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in

--- a/test/asset_approve.test.mligo
+++ b/test/asset_approve.test.mligo
@@ -3,7 +3,7 @@
 #import "./helper/asset.mligo" "Asset_helper"
 #import "./asset.instance.mligo" "Asset"
 
-type storage = Asset.storage
+type storage = Asset.FA12_TOKEN.storage
 
 let test_success_approve =
     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
@@ -25,7 +25,7 @@ let test_failure_approve_modify_allowance =
     let () = Test.set_source owner1 in
     let approve_op1 = (op1, 1n) in
     let r = Test.transfer_to_contract asset.contr (Approve approve_op1) 0tez in
-    Assert.string_failure r Asset.FA12.Errors.vulnerable_operation
+    Assert.string_failure r Asset.FA12_TOKEN.FA12.Errors.vulnerable_operation
 
 let test_success_approve_modify_allowance =
     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in

--- a/test/asset_extra_entrypoint.test.mligo
+++ b/test/asset_extra_entrypoint.test.mligo
@@ -1,0 +1,22 @@
+#import "./helper/bootstrap.mligo" "Bootstrap"
+#import "./helper/assert.mligo" "Assert"
+#import "./helper/asset.mligo" "Asset_helper"
+#import "./asset.instance.mligo" "Asset"
+
+type storage = Asset.storage
+
+let test_extra_entrypoint_success =
+    let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
+    let (owner1, owner2, owner3) = owners in
+    let (op1, op2, op3) = operators in
+
+    let () = Test.set_source owner1 in
+    let _ = Test.transfer_exn asset.taddr (X ()) 0tez in
+    let () = Asset_helper.assert_balances asset.taddr ((owner1, 10n), (owner2, 10n), (owner3, 10n)) in
+    let () = Asset_helper.assert_allowance asset.taddr owner1 op1 10n in
+    let () = Asset_helper.assert_allowance asset.taddr owner2 op1 5n in
+    let () = Asset_helper.assert_allowance asset.taddr owner2 op2 5n in
+    let () = Asset_helper.assert_allowance asset.taddr owner3 op1 4n in
+    let () = Asset_helper.assert_allowance asset.taddr owner3 op2 3n in
+    let () = Asset_helper.assert_allowance asset.taddr owner3 op3 3n in
+    ()

--- a/test/asset_transfer.test.mligo
+++ b/test/asset_transfer.test.mligo
@@ -3,7 +3,7 @@
 #import "./helper/asset.mligo" "Asset_helper"
 #import "./asset.instance.mligo" "Asset"
 
-type storage = Asset.FA12_TOKEN.storage
+type storage = Asset.storage
 
 let test_atomic_transfer_success =
     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
@@ -43,7 +43,7 @@ let test_failure_transfer_without_enough_allowance =
     let () = Test.set_source op2 in
     let transfer_1 = (owner2, (owner1, 6n)) in
     let r = Test.transfer_to_contract asset.contr (Transfer transfer_1) 0tez in
-    Assert.allowance_failure r Asset.FA12_TOKEN.FA12.Errors.not_enough_allowance
+    Assert.allowance_failure r Asset.FA12.Errors.not_enough_allowance
 
 let test_success_transfer_allowance_must_decrease =
     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
@@ -75,7 +75,7 @@ let test_failure_owner_transfer_without_enough_balance =
     let () = Test.set_source owner2 in
     let transfer_1 = (owner2, (owner1, 11n)) in
     let r = Test.transfer_to_contract asset.contr (Transfer transfer_1) 0tez in
-    Assert.string_failure r Asset.FA12_TOKEN.FA12.Errors.not_enough_balance
+    Assert.string_failure r Asset.FA12.Errors.not_enough_balance
 
 let test_failure_transfer_without_enough_balance =
     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
@@ -91,4 +91,4 @@ let test_failure_transfer_without_enough_balance =
     let () = Asset_helper.assert_balances asset.taddr ((owner1, 11n), (owner2, 9n), (owner3, 10n)) in
 
     let r = Test.transfer_to_contract asset.contr (Transfer transfer_2) 0tez in
-    Assert.allowance_failure r Asset.FA12_TOKEN.FA12.Errors.not_enough_allowance
+    Assert.allowance_failure r Asset.FA12.Errors.not_enough_allowance

--- a/test/asset_transfer.test.mligo
+++ b/test/asset_transfer.test.mligo
@@ -75,7 +75,7 @@ let test_failure_owner_transfer_without_enough_balance =
     let () = Test.set_source owner2 in
     let transfer_1 = (owner2, (owner1, 11n)) in
     let r = Test.transfer_to_contract asset.contr (Transfer transfer_1) 0tez in
-    Assert.string_failure r Asset.FA12.Errors.not_enough_balance
+    Assert.string_failure r Asset.FA12_TOKEN.FA12.Errors.not_enough_balance
 
 // let test_failure_transfer_without_enough_balance =
 //     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in

--- a/test/asset_transfer.test.mligo
+++ b/test/asset_transfer.test.mligo
@@ -35,15 +35,15 @@ let test_multiple_transfer_success =
     let () = Asset_helper.assert_balances asset.taddr ((owner1, 8n), (owner2, 7n), (owner3, 15n)) in
     ()
 
-// let test_failure_transfer_without_enough_allowance =
-//     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
-//     let (owner1, owner2, _owner3) = owners in
-//     let (_op1, op2, _op3) = operators in
+let test_failure_transfer_without_enough_allowance =
+    let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
+    let (owner1, owner2, _owner3) = owners in
+    let (_op1, op2, _op3) = operators in
 
-//     let () = Test.set_source op2 in
-//     let transfer_1 = (owner2, (owner1, 6n)) in
-//     let r = Test.transfer_to_contract asset.contr (Transfer transfer_1) 0tez in
-//     Assert.allowance_failure r Asset.FA12.Errors.not_enough_allowance
+    let () = Test.set_source op2 in
+    let transfer_1 = (owner2, (owner1, 6n)) in
+    let r = Test.transfer_to_contract asset.contr (Transfer transfer_1) 0tez in
+    Assert.allowance_failure r Asset.FA12_TOKEN.FA12.Errors.not_enough_allowance
 
 let test_success_transfer_allowance_must_decrease =
     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
@@ -77,18 +77,18 @@ let test_failure_owner_transfer_without_enough_balance =
     let r = Test.transfer_to_contract asset.contr (Transfer transfer_1) 0tez in
     Assert.string_failure r Asset.FA12_TOKEN.FA12.Errors.not_enough_balance
 
-// let test_failure_transfer_without_enough_balance =
-//     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
-//     let (owner1, owner2, owner3) = owners in
-//     let (_op1, op2, _op3) = operators in
+let test_failure_transfer_without_enough_balance =
+    let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
+    let (owner1, owner2, owner3) = owners in
+    let (_op1, op2, _op3) = operators in
 
-//     let transfer_1 = (owner2, (owner1, 1n)) in
-//     let transfer_2 = (owner2, (owner3, 10n)) in
+    let transfer_1 = (owner2, (owner1, 1n)) in
+    let transfer_2 = (owner2, (owner3, 10n)) in
 
-//     let () = Test.set_source op2 in
-//     let r = Test.transfer_to_contract asset.contr (Transfer transfer_1) 0tez in
-//     let () = Assert.tx_success r in
-//     let () = Asset_helper.assert_balances asset.taddr ((owner1, 11n), (owner2, 9n), (owner3, 10n)) in
+    let () = Test.set_source op2 in
+    let r = Test.transfer_to_contract asset.contr (Transfer transfer_1) 0tez in
+    let () = Assert.tx_success r in
+    let () = Asset_helper.assert_balances asset.taddr ((owner1, 11n), (owner2, 9n), (owner3, 10n)) in
 
-//     let r = Test.transfer_to_contract asset.contr (Transfer transfer_2) 0tez in
-//     Assert.allowance_failure r Asset.FA12.Errors.not_enough_allowance
+    let r = Test.transfer_to_contract asset.contr (Transfer transfer_2) 0tez in
+    Assert.allowance_failure r Asset.FA12_TOKEN.FA12.Errors.not_enough_allowance

--- a/test/asset_transfer.test.mligo
+++ b/test/asset_transfer.test.mligo
@@ -3,7 +3,7 @@
 #import "./helper/asset.mligo" "Asset_helper"
 #import "./asset.instance.mligo" "Asset"
 
-type storage = Asset.storage
+type storage = Asset.FA12_TOKEN.storage
 
 let test_atomic_transfer_success =
     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
@@ -13,7 +13,7 @@ let test_atomic_transfer_success =
     let transfer_1 = (owner1, (owner2, 2n)) in
 
     let () = Test.set_source owner1 in
-    let _ = Test.transfer_to_contract_exn asset.contr (Transfer transfer_1) 0tez in
+    let _ = Test.transfer_exn asset.taddr (Transfer (transfer_1)) 0tez in
     let () = Asset_helper.assert_balances asset.taddr ((owner1, 8n), (owner2, 12n), (owner3, 10n)) in
     ()
 
@@ -35,15 +35,15 @@ let test_multiple_transfer_success =
     let () = Asset_helper.assert_balances asset.taddr ((owner1, 8n), (owner2, 7n), (owner3, 15n)) in
     ()
 
-let test_failure_transfer_without_enough_allowance =
-    let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
-    let (owner1, owner2, _owner3) = owners in
-    let (_op1, op2, _op3) = operators in
+// let test_failure_transfer_without_enough_allowance =
+//     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
+//     let (owner1, owner2, _owner3) = owners in
+//     let (_op1, op2, _op3) = operators in
 
-    let () = Test.set_source op2 in
-    let transfer_1 = (owner2, (owner1, 6n)) in
-    let r = Test.transfer_to_contract asset.contr (Transfer transfer_1) 0tez in
-    Assert.allowance_failure r Asset.FA12.Errors.not_enough_allowance
+//     let () = Test.set_source op2 in
+//     let transfer_1 = (owner2, (owner1, 6n)) in
+//     let r = Test.transfer_to_contract asset.contr (Transfer transfer_1) 0tez in
+//     Assert.allowance_failure r Asset.FA12.Errors.not_enough_allowance
 
 let test_success_transfer_allowance_must_decrease =
     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
@@ -77,18 +77,18 @@ let test_failure_owner_transfer_without_enough_balance =
     let r = Test.transfer_to_contract asset.contr (Transfer transfer_1) 0tez in
     Assert.string_failure r Asset.FA12.Errors.not_enough_balance
 
-let test_failure_transfer_without_enough_balance =
-    let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
-    let (owner1, owner2, owner3) = owners in
-    let (_op1, op2, _op3) = operators in
+// let test_failure_transfer_without_enough_balance =
+//     let (asset, owners, operators) = Bootstrap.boot_asset_and_accounts(10n, 10n, 10n) in
+//     let (owner1, owner2, owner3) = owners in
+//     let (_op1, op2, _op3) = operators in
 
-    let transfer_1 = (owner2, (owner1, 1n)) in
-    let transfer_2 = (owner2, (owner3, 10n)) in
+//     let transfer_1 = (owner2, (owner1, 1n)) in
+//     let transfer_2 = (owner2, (owner3, 10n)) in
 
-    let () = Test.set_source op2 in
-    let r = Test.transfer_to_contract asset.contr (Transfer transfer_1) 0tez in
-    let () = Assert.tx_success r in
-    let () = Asset_helper.assert_balances asset.taddr ((owner1, 11n), (owner2, 9n), (owner3, 10n)) in
+//     let () = Test.set_source op2 in
+//     let r = Test.transfer_to_contract asset.contr (Transfer transfer_1) 0tez in
+//     let () = Assert.tx_success r in
+//     let () = Asset_helper.assert_balances asset.taddr ((owner1, 11n), (owner2, 9n), (owner3, 10n)) in
 
-    let r = Test.transfer_to_contract asset.contr (Transfer transfer_2) 0tez in
-    Assert.allowance_failure r Asset.FA12.Errors.not_enough_allowance
+//     let r = Test.transfer_to_contract asset.contr (Transfer transfer_2) 0tez in
+//     Assert.allowance_failure r Asset.FA12.Errors.not_enough_allowance

--- a/test/helper/assert.mligo
+++ b/test/helper/assert.mligo
@@ -25,13 +25,12 @@ let tx_success (res: test_exec_result) : unit =
 //   let _ = Test.transfer_to_contract_exn (Test.to_contract taux) () 0tez in
 //   Option.unopt (Test.get_storage taux)
 
-// (* Assert contract call results in failwith with given `"notEnoughAllowance" (required, current)` format *)
-// let allowance_failure (res : test_exec_result) (expected : string) : unit =
-//     // let expected = Test.eval expected in // instead of decompile_hack
-//     match res with
-//         | Fail (Rejected (actual,_)) -> 
-//             let ec : string * (nat * nat) = decompile_hack actual in
-//             assert (ec.0 = expected)
-//         | Fail (Balance_too_low _err) -> Test.failwith "contract failed: balance too low"
-//         | Fail (Other s) -> Test.failwith s
-//         | Success _ -> Test.failwith "Transaction should fail"
+(* Assert contract call results in failwith with given `"notEnoughAllowance" (required, current)` format *)
+let allowance_failure (res : test_exec_result) (expected : string) : unit =
+    match res with
+        | Fail (Rejected (actual,_)) -> 
+            let ec : string * (nat * nat) = Test.decompile actual in
+            assert (ec.0 = expected)
+        | Fail (Balance_too_low _err) -> Test.failwith "contract failed: balance too low"
+        | Fail (Other s) -> Test.failwith s
+        | Success _ -> Test.failwith "Transaction should fail"

--- a/test/helper/assert.mligo
+++ b/test/helper/assert.mligo
@@ -17,21 +17,21 @@ let tx_success (res: test_exec_result) : unit =
         | Fail _ -> Test.failwith "Transaction should not fail"
 
 (* Decompile a michelson_program for a given type *)
-let decompile_hack (type a) (m : michelson_program) : a =
-  let cte = Test.register_constant m in
-  let f (() : unit) (_ : a option) : operation list * a option =
-    [], Some (Tezos.constant cte : a) in
-  let taux, _, _ = Test.originate f None 0tez in
-  let _ = Test.transfer_to_contract_exn (Test.to_contract taux) () 0tez in
-  Option.unopt (Test.get_storage taux)
+// let decompile_hack (type a) (m : michelson_program) : a =
+//   let cte = Test.register_constant m in
+//   let f (() : unit) (_ : a option) : operation list * a option =
+//     [], Some (Tezos.constant cte : a) in
+//   let taux, _, _ = Test.originate f None 0tez in
+//   let _ = Test.transfer_to_contract_exn (Test.to_contract taux) () 0tez in
+//   Option.unopt (Test.get_storage taux)
 
-(* Assert contract call results in failwith with given `"notEnoughAllowance" (required, current)` format *)
-let allowance_failure (res : test_exec_result) (expected : string) : unit =
-    // let expected = Test.eval expected in // instead of decompile_hack
-    match res with
-        | Fail (Rejected (actual,_)) -> 
-            let ec : string * (nat * nat) = decompile_hack actual in
-            assert (ec.0 = expected)
-        | Fail (Balance_too_low _err) -> Test.failwith "contract failed: balance too low"
-        | Fail (Other s) -> Test.failwith s
-        | Success _ -> Test.failwith "Transaction should fail"
+// (* Assert contract call results in failwith with given `"notEnoughAllowance" (required, current)` format *)
+// let allowance_failure (res : test_exec_result) (expected : string) : unit =
+//     // let expected = Test.eval expected in // instead of decompile_hack
+//     match res with
+//         | Fail (Rejected (actual,_)) -> 
+//             let ec : string * (nat * nat) = decompile_hack actual in
+//             assert (ec.0 = expected)
+//         | Fail (Balance_too_low _err) -> Test.failwith "contract failed: balance too low"
+//         | Fail (Other s) -> Test.failwith s
+//         | Success _ -> Test.failwith "Transaction should fail"

--- a/test/helper/assert.mligo
+++ b/test/helper/assert.mligo
@@ -16,15 +16,6 @@ let tx_success (res: test_exec_result) : unit =
             Test.failwith "Transaction should not fail"
         | Fail _ -> Test.failwith "Transaction should not fail"
 
-(* Decompile a michelson_program for a given type *)
-// let decompile_hack (type a) (m : michelson_program) : a =
-//   let cte = Test.register_constant m in
-//   let f (() : unit) (_ : a option) : operation list * a option =
-//     [], Some (Tezos.constant cte : a) in
-//   let taux, _, _ = Test.originate f None 0tez in
-//   let _ = Test.transfer_to_contract_exn (Test.to_contract taux) () 0tez in
-//   Option.unopt (Test.get_storage taux)
-
 (* Assert contract call results in failwith with given `"notEnoughAllowance" (required, current)` format *)
 let allowance_failure (res : test_exec_result) (expected : string) : unit =
     match res with

--- a/test/helper/asset.mligo
+++ b/test/helper/asset.mligo
@@ -1,7 +1,7 @@
 #import "../asset.instance.mligo" "Asset"
 
-type taddr = (Asset.FA12_TOKEN.parameter, Asset.FA12_TOKEN.storage) typed_address
-type contr = Asset.FA12_TOKEN.parameter contract
+type taddr = (Asset.parameter, Asset.storage) typed_address
+type contr = Asset.parameter contract
 type originated = {
     addr: address;
     taddr: taddr;
@@ -9,7 +9,7 @@ type originated = {
 }
 
 (* Base storage *)
-let base_storage (ledger, token_metadata, total_supply, metadata : Asset.FA12_TOKEN.FA12.Ledger.t * Asset.FA12_TOKEN.FA12.TokenMetadata.t * nat * Asset.FA12_TOKEN.FA12.Storage.Metadata.t) : Asset.FA12_TOKEN.storage = {
+let base_storage (ledger, token_metadata, total_supply, metadata : Asset.FA12.Ledger.t * Asset.FA12.TokenMetadata.t * nat * Asset.FA12.Storage.Metadata.t) : Asset.storage = {
     ledger = ledger;
     token_metadata = token_metadata;
     total_supply = total_supply;
@@ -17,15 +17,15 @@ let base_storage (ledger, token_metadata, total_supply, metadata : Asset.FA12_TO
 }
 
 (* Originate a Asset contract with given init_storage storage *)
-let originate (init_storage : Asset.FA12_TOKEN.storage) =
-    let result = Test.originate (contract_of Asset.FA12_TOKEN) init_storage 0mutez in
+let originate (init_storage : Asset.storage) =
+    let result = Test.originate (contract_of Asset) init_storage 0mutez in
     let contr = Test.to_contract result.addr in
     let addr = Tezos.address contr in
     {addr = addr; taddr = result.addr; contr = contr}
 
 (* Verifies allowance amount for a given owner and spender *)
 let assert_allowance
-    (contract_address : (Asset.FA12_TOKEN.parameter, Asset.FA12_TOKEN.storage) typed_address )
+    (contract_address : (Asset.parameter, Asset.storage) typed_address )
     (owner : address)
     (spender : address)
     (expected_allowance : nat) =
@@ -42,7 +42,7 @@ let assert_allowance
     
 (* Verifies balances of 3 accounts *)
 let assert_balances
-  (contract_address : ((Asset.FA12_TOKEN.parameter), Asset.FA12_TOKEN.storage) typed_address )
+  (contract_address : ((Asset.parameter), Asset.storage) typed_address )
   (a, b, c : (address * nat) * (address * nat) * (address * nat)) =
   let (owner1, balance1) = a in
   let (owner2, balance2) = b in

--- a/test/helper/asset.mligo
+++ b/test/helper/asset.mligo
@@ -20,6 +20,7 @@ let base_storage (ledger, token_metadata, total_supply, metadata : Asset.FA12_TO
 let originate (init_storage : Asset.FA12_TOKEN.storage) =
     // let (taddr, _, _)
     let result = Test.originate (contract_of Asset.FA12_TOKEN) init_storage 0mutez in
+    // let () = Test.log(result) in
     let contr = Test.to_contract result.addr in
     let addr = Tezos.address contr in
     {addr = addr; taddr = result.addr; contr = contr}
@@ -43,7 +44,7 @@ let assert_allowance
     
 (* Verifies balances of 3 accounts *)
 let assert_balances
-  (contract_address : ([@layout tree] Asset.FA12_TOKEN.parameter, Asset.FA12_TOKEN.storage) typed_address )
+  (contract_address : ([@layout tree] (Asset.FA12_TOKEN.parameter), Asset.FA12_TOKEN.storage) typed_address )
   (a, b, c : (address * nat) * (address * nat) * (address * nat)) =
   let (owner1, balance1) = a in
   let (owner2, balance2) = b in

--- a/test/helper/asset.mligo
+++ b/test/helper/asset.mligo
@@ -1,7 +1,7 @@
 #import "../asset.instance.mligo" "Asset"
 
-type taddr = (Asset.parameter, Asset.storage) typed_address
-type contr = Asset.parameter contract
+type taddr = ([@layout tree] Asset.FA12_TOKEN.parameter, Asset.FA12_TOKEN.storage) typed_address
+type contr = [@layout tree] Asset.FA12_TOKEN.parameter contract
 type originated = {
     addr: address;
     taddr: taddr;
@@ -9,7 +9,7 @@ type originated = {
 }
 
 (* Base storage *)
-let base_storage (ledger, token_metadata, total_supply, metadata : Asset.FA12.Ledger.t * Asset.FA12.TokenMetadata.t * nat * Asset.FA12.Storage.Metadata.t) : Asset.storage = {
+let base_storage (ledger, token_metadata, total_supply, metadata : Asset.FA12_TOKEN.FA12.Ledger.t * Asset.FA12_TOKEN.FA12.TokenMetadata.t * nat * Asset.FA12_TOKEN.FA12.Storage.Metadata.t) : Asset.FA12_TOKEN.storage = {
     ledger = ledger;
     token_metadata = token_metadata;
     total_supply = total_supply;
@@ -17,15 +17,16 @@ let base_storage (ledger, token_metadata, total_supply, metadata : Asset.FA12.Le
 }
 
 (* Originate a Asset contract with given init_storage storage *)
-let originate (init_storage : Asset.storage) =
-    let (taddr, _, _) = Test.originate_uncurried Asset.main init_storage 0mutez in
-    let contr = Test.to_contract taddr in
+let originate (init_storage : Asset.FA12_TOKEN.storage) =
+    // let (taddr, _, _)
+    let result = Test.originate (contract_of Asset.FA12_TOKEN) init_storage 0mutez in
+    let contr = Test.to_contract result.addr in
     let addr = Tezos.address contr in
-    {addr = addr; taddr = taddr; contr = contr}
+    {addr = addr; taddr = result.addr; contr = contr}
 
 (* Verifies allowance amount for a given owner and spender *)
 let assert_allowance
-    (contract_address : (Asset.parameter, Asset.storage) typed_address )
+    (contract_address : ([@layout tree] Asset.FA12_TOKEN.parameter, Asset.FA12_TOKEN.storage) typed_address )
     (owner : address)
     (spender : address)
     (expected_allowance : nat) =
@@ -42,7 +43,7 @@ let assert_allowance
     
 (* Verifies balances of 3 accounts *)
 let assert_balances
-  (contract_address : (Asset.parameter, Asset.storage) typed_address )
+  (contract_address : ([@layout tree] Asset.FA12_TOKEN.parameter, Asset.FA12_TOKEN.storage) typed_address )
   (a, b, c : (address * nat) * (address * nat) * (address * nat)) =
   let (owner1, balance1) = a in
   let (owner2, balance2) = b in

--- a/test/helper/asset.mligo
+++ b/test/helper/asset.mligo
@@ -1,7 +1,7 @@
 #import "../asset.instance.mligo" "Asset"
 
-type taddr = ([@layout tree] Asset.FA12_TOKEN.parameter, Asset.FA12_TOKEN.storage) typed_address
-type contr = [@layout tree] Asset.FA12_TOKEN.parameter contract
+type taddr = (Asset.FA12_TOKEN.parameter, Asset.FA12_TOKEN.storage) typed_address
+type contr = Asset.FA12_TOKEN.parameter contract
 type originated = {
     addr: address;
     taddr: taddr;
@@ -18,16 +18,14 @@ let base_storage (ledger, token_metadata, total_supply, metadata : Asset.FA12_TO
 
 (* Originate a Asset contract with given init_storage storage *)
 let originate (init_storage : Asset.FA12_TOKEN.storage) =
-    // let (taddr, _, _)
     let result = Test.originate (contract_of Asset.FA12_TOKEN) init_storage 0mutez in
-    // let () = Test.log(result) in
     let contr = Test.to_contract result.addr in
     let addr = Tezos.address contr in
     {addr = addr; taddr = result.addr; contr = contr}
 
 (* Verifies allowance amount for a given owner and spender *)
 let assert_allowance
-    (contract_address : ([@layout tree] Asset.FA12_TOKEN.parameter, Asset.FA12_TOKEN.storage) typed_address )
+    (contract_address : (Asset.FA12_TOKEN.parameter, Asset.FA12_TOKEN.storage) typed_address )
     (owner : address)
     (spender : address)
     (expected_allowance : nat) =
@@ -44,7 +42,7 @@ let assert_allowance
     
 (* Verifies balances of 3 accounts *)
 let assert_balances
-  (contract_address : ([@layout tree] (Asset.FA12_TOKEN.parameter), Asset.FA12_TOKEN.storage) typed_address )
+  (contract_address : ((Asset.FA12_TOKEN.parameter), Asset.FA12_TOKEN.storage) typed_address )
   (a, b, c : (address * nat) * (address * nat) * (address * nat)) =
   let (owner1, balance1) = a in
   let (owner2, balance2) = b in

--- a/test/helper/bootstrap.mligo
+++ b/test/helper/bootstrap.mligo
@@ -29,8 +29,9 @@ let boot_asset_and_accounts (a, b, c : nat * nat * nat) =
     in
 
     let token_info = (Map.empty: (string, bytes) map) in
-    let token_metadata = 
-        { token_id   = 0n; token_info = token_info; }
+    let token_metadata = Big_map.literal([ 
+        (0n, { token_id   = 0n; token_info = token_info; })
+    ])
     in
     let metadata = Big_map.literal([
         ("", Bytes.pack("tezos-storage:contents"));


### PR DESCRIPTION
remove decompile_hack (because `Test.decompile` has been fixed)
enforce `[@layout comb]` in the token `parameter` definition  (to fit the one that is produced by compiler) => TO IMPROVE
add an extra entrypoint in the token example.