### PR TITLE
fix layout issue

### DIFF
--- a/test/asset.instance.mligo
+++ b/test/asset.instance.mligo
@@ -3,13 +3,12 @@
 type storage = FA12.storage
 
 type parameter = [@layout comb] 
-| X of unit     // You can add an additionnal entrypoint to implement a specific feature for the token
-| GetTotalSupply of FA12.getTotalSupply
-| GetBalance of FA12.getBalance  
-| GetAllowance of FA12.getAllowance 
-| Approve of FA12.approve 
 | Transfer of FA12.transfer
-
+| Approve of FA12.approve 
+| GetAllowance of FA12.getAllowance 
+| GetBalance of FA12.getBalance  
+| GetTotalSupply of FA12.getTotalSupply
+| X of unit     // You can add an additionnal entrypoint to implement a specific feature for the token
 
 [@entry]
 let transfer (p: FA12.transfer) (s: storage) : operation list * storage =

--- a/test/helper/asset.mligo
+++ b/test/helper/asset.mligo
@@ -18,14 +18,14 @@ let base_storage (ledger, token_metadata, total_supply, metadata : Asset.FA12.Le
 
 (* Originate a Asset contract with given init_storage storage *)
 let originate (init_storage : Asset.storage) =
-    let result = Test.originate (contract_of Asset) init_storage 0mutez in
-    let contr = Test.to_contract result.addr in
-    let addr = Tezos.address contr in
-    {addr = addr; taddr = result.addr; contr = contr}
+    let { addr;code = _code; size = _size} = Test.originate (contract_of Asset) init_storage 0mutez in
+    let contr = Test.to_contract addr in
+    let addr_contr = Tezos.address contr in
+    {addr = addr_contr; taddr = addr; contr = contr}
 
 (* Verifies allowance amount for a given owner and spender *)
 let assert_allowance
-    (contract_address : (Asset.parameter, Asset.storage) typed_address )
+    (contract_address : ((Asset parameter_of), Asset.storage) typed_address )
     (owner : address)
     (spender : address)
     (expected_allowance : nat) =
@@ -42,7 +42,7 @@ let assert_allowance
     
 (* Verifies balances of 3 accounts *)
 let assert_balances
-  (contract_address : ((Asset.parameter), Asset.storage) typed_address )
+  (contract_address : ((Asset parameter_of), Asset.storage) typed_address )
   (a, b, c : (address * nat) * (address * nat) * (address * nat)) =
   let (owner1, balance1) = a in
   let (owner2, balance2) = b in


### PR DESCRIPTION
layout issue: use the `parameter_of` instruction to ensure the `typed_address` deals with the correct entrypoints order.